### PR TITLE
Bugfix: Extracting data from byte response instead of string

### DIFF
--- a/httpParser.py
+++ b/httpParser.py
@@ -26,23 +26,20 @@ class HttpParser:
         Return:
             HTTP status code.
         """
-        #print(">>>>",httpRes)
-        if(httpRes != None):
-            retParseResponse=str(httpRes).partition("+IPD,")[2]
-            #print(">>>>>>>>>>>>>>>>>",retParseResponse)
-            retParseResponse=retParseResponse.split(r"\r\n\r\n");
-            #print(">>>>>>>>>>>>>>>>>",retParseResponse[0])
-            self.__httpResponse = retParseResponse[1]
-            #print(">>>>>>>>>>>>>>>>>???",retParseResponse[1])  
-            self.__httpHeader=str(retParseResponse[0]).partition(":")[2]
-            #print("--",self.__httpHeader)
+        if httpRes is not None:
+            self.__httpResponse = httpRes.split(b'\r\n\r\n')[3]
+
+            header = str(httpRes.split(b'\r\n\r\n')[2], 'utf-8')
+            self.__httpHeader = header[header.index('HTTP'):]
+
             for code in str(self.__httpHeader.partition(r"\r\n")[0]).split():
                 if code.isdigit():
-                    self.__httpErrCode=int(code)
-                    
-            if(self.__httpErrCode != 200):
-                self.__httpResponse=None
-                
+                    self.__httpErrCode = int(code)
+                    break
+
+            if self.__httpErrCode != 200:
+                self.__httpResponse = None
+
             return self.__httpErrCode
         else:
             return 0


### PR DESCRIPTION
The response of get call looks like this:
`{"key": "value}'`

As you can see there is an apostrophe at the end. This comes because of the wrong conversion of byte to string.
`b'HTTP/1.1 200 OK\r\n ............ {"key": "value}'`

after a lot of splits the apostrophe was forgotten.

This PR extracts data from the upstream without converting it to string.

After the response [here](https://github.com/noyelseth/rpi-pico-micropython-esp8266-lib/blob/f6b8f7ce016c1cdc09ac800fca8eb48dd18dc47b/example/http-get-post/main.py#L66), we could followings:

Parsing to string `res = str(httpRes, 'utf-8')` and then converting it to json `json.loads(res)`